### PR TITLE
Add the option to submit the pubkey of a new user when creating

### DIFF
--- a/examples/commands.txt
+++ b/examples/commands.txt
@@ -38,6 +38,9 @@ User
 ## new user
 ssh-permit-a38 user obelix add
 
+## new user non-interactive
+ssh-permit-a38 user obelix add "ssh-rsa ABC...xyz obelix@gaul.fr"
+
 ## list all users
 ssh-permit-a38 user list
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,9 +88,13 @@ fn main() {
                 .index(1))
                 .alias("users")
 
-                // user <user> add
+                // user <user> add [<sshkey>]
                 .subcommand(
                     SubCommand::with_name("add")
+                        .arg(Arg::with_name("pubkey")
+                            .help("User")
+                            .index(1)
+                            .required(false))
                 )
                 // user <user> remove
                 .subcommand(
@@ -253,8 +257,9 @@ fn main() {
     else if let Some(matches) = matches.subcommand_matches("user") {
         let user_id = matches.value_of("user").unwrap_or("");
 
-        if matches.subcommand_matches("add").is_some() {
-            subcommand_user::add(&mut db, &user_id);
+        if let Some(matches) = matches.subcommand_matches("add") {
+            let pubkey = matches.value_of("pubkey").unwrap_or("");
+            subcommand_user::add(&mut db, &user_id, &pubkey);
         } else if matches.subcommand_matches("remove").is_some() {
             subcommand_user::remove(&mut db, &user_id);
         } else if let Some(matches) = matches.subcommand_matches("list") {

--- a/src/subcommand_user.rs
+++ b/src/subcommand_user.rs
@@ -2,24 +2,28 @@ use cli_flow;
 use database::{Database, User};
 use std::io;
 
-pub fn add(db: &mut Database, user_id: &str) {
+pub fn add(db: &mut Database, user_id: &str, pkey: &str) {
     // check user is not present
     if db.user_get(user_id).is_some() {
         cli_flow::errorln(&format!("User {} already exists", user_id));
     }
 
-    // read public key
-    cli_flow::promptln(&format!(
-        "Paste the public key of {} and press the Enter key:",
-        user_id
-    ));
-
     let mut public_key = String::new();
-    io::stdin()
-        .read_line(&mut public_key)
-        .ok()
-        .expect("Couldn't read public key");
 
+    if pkey.len() > 0 {
+        public_key = pkey.to_string();
+    } else {
+        // read public key
+        cli_flow::promptln(&format!(
+            "Paste the public key of {} and press the Enter key:",
+            user_id
+        ));
+
+        io::stdin()
+            .read_line(&mut public_key)
+            .ok()
+            .expect("Couldn't read public key");
+    }
     // TODO:; daring assumption, validate...
     if !public_key.starts_with("ssh-") {
         cli_flow::errorln("Invalid public ssh key format")


### PR DESCRIPTION
I am calling ssh-permit-a38 from other scripts and found it handy to have an option to add users with keys in one call